### PR TITLE
Refactor flag args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 
 debug
 *.csv
+
+align
+bin/*

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ _A general purpose package that aligns text_
 [![GoDoc](https://img.shields.io/badge/api-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/Guitarbum722/align) 
 [![Build Status](https://travis-ci.org/Guitarbum722/align.svg?branch=master)](https://travis-ci.org/Guitarbum722/align)
 
-The focus of this package is to provide a fast, efficient, and useful library for aligning text.
+The focus of this package is to provide a fast, efficient, and useful tool for aligning text.
 
 ### Included
 
-* Fully capable library, waiting to be consumed by your program.
 * A simple yet usefule CLI with options to specify your delimiter, input and output files, etc.
 * Align by any string as your delimiter or separator, not just a single character.
 * If your separator string is contained within the data itself, it can be escaped by specifying
@@ -31,27 +30,25 @@ $ go install
 ### Usage - CLI examples
 
 ```
-Usage: align [-sep] [-output] [-file] [-qual]
+Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a]
 Options:
   -h | --help  : help
-  -file        : input file.  If not specified, pipe input to stdin
-  -output      : output file. (defaults to stdout)
-  -qual        : text qualifier (if applicable)
-  -sep         : delimiter. (defaults to ',')
-  -outsep      : output delimiter (defaults to value of -sep)
-  -left        : left justification. (default)
-  -center      : center justification
-  -right       : right justification
+  -f           : input file.  If not specified, pipe input to stdin
+  -o           : output file. (defaults to stdout)
+  -q           : text qualifier (if applicable)
+  -s           : delimiter. (defaults to ',')
+  -d           : output delimiter (defaults to the value of sep)
+  -a           : <left>, <right>, <center> justification (default: left)
 ```
 
 _Specify your input file, output file, delimiter._
-*You can also pipe input to Stdin (if the `-file` option is provided, it will take precedence over Stdin)*
-If no `-output` option is provided, Stdout will be used.
+*You can also pipe input to Stdin (if the `-f` option is provided, it will take precedence over Stdin)*
+If no `-o` option is provided, Stdout will be used.
 
 ```sh
-$ align -file input_file.csv -output output_file.csv
+$ align -f input_file.csv -output output_file.csv
 
-$ align -file input_file.csv -output 
+$ align -f input_file.csv -output 
 
 $ cat awesome.csv | align
 ```
@@ -59,7 +56,7 @@ $ cat awesome.csv | align
 Do you have rows with a different number of fields?  This might be more common with code, but `align` doesn't care!
 
 ```
-$ echo "field1|field2\nValue1|Value2\nCoolValue1|CoolValue2|CoolValue3" | align -sep \|
+$ echo "field1|field2\nValue1|Value2\nCoolValue1|CoolValue2|CoolValue3" | align -s \|
 field1     | field2
 Value1     | Value2
 CoolValue1 | CoolValue2 | CoolValue3

--- a/main.go
+++ b/main.go
@@ -32,8 +32,7 @@ func main() {
 func run() (int, error) {
 	args := os.Args[1:]
 
-	// defaults
-	sep := ","
+	sep := "," // default
 	var outSep string
 	var input io.Reader
 	var output io.Writer
@@ -44,25 +43,20 @@ func run() (int, error) {
 	}
 
 	if flags.Has("sep", args) {
-		if len(args) < 2 {
-			return 1, errors.New("argument to -sep required")
+		val, err := flags.Value("sep", args)
+		if !validArg(err, val) {
+			return 1, errors.New("invalid entry for -sep \n" + usage)
 		}
-		delimiter, err := flags.Value("sep", args)
-		if err != nil {
-			return 1, err
-		}
-		sep = delimiter
+		sep = val
 	}
 
 	if flags.Has("outsep", args) {
-		if len(args) < 2 {
-			return 1, errors.New("argument to -outsep required")
+		outSep = sep
+		val, err := flags.Value("outsep", args)
+		if !validArg(err, val) {
+			return 1, errors.New("invalid entry for -outsep \n" + usage)
 		}
-		delimiter, err := flags.Value("outsep", args)
-		if err != nil {
-			return 1, err
-		}
-		outSep = delimiter
+		outSep = val
 	} else {
 		outSep = sep
 	}
@@ -72,9 +66,10 @@ func run() (int, error) {
 	if (fi.Mode() & os.ModeCharDevice) == 0 {
 		if flags.Has("file", args) {
 			fn, err := flags.Value("file", args)
-			if err != nil {
-				return 1, err
+			if !validArg(err, fn) {
+				return 1, errors.New("invalid entry for -file \n" + usage)
 			}
+
 			f, err := os.Open(fn)
 			if err != nil {
 				return 1, err
@@ -87,9 +82,10 @@ func run() (int, error) {
 	} else {
 		if flags.Has("file", args) {
 			fn, err := flags.Value("file", args)
-			if err != nil {
-				return 1, err
+			if !validArg(err, fn) {
+				return 1, errors.New("invalid entry for -file \n" + usage)
 			}
+
 			f, err := os.Open(fn)
 			if err != nil {
 				return 1, err
@@ -97,18 +93,15 @@ func run() (int, error) {
 			defer f.Close()
 			input = f
 		} else {
-			return 1, errors.New("no input provided")
+			return 1, errors.New("no input provided \n" + usage)
 		}
 	}
 
 	// if --output flag is not provided with a file name, then use Stdout
 	if flags.Has("output", args) {
-		if len(args) < 2 {
-			return 1, errors.New("argument to -output required")
-		}
 		fn, err := flags.Value("output", args)
-		if err != nil {
-			return 1, err
+		if !validArg(err, fn) {
+			return 1, errors.New("invalid entry for -output \n" + usage)
 		}
 		f, err := os.Create(fn)
 		if err != nil {
@@ -122,8 +115,8 @@ func run() (int, error) {
 
 	if flags.Has("qual", args) {
 		q, err := flags.Value("qual", args)
-		if err != nil {
-			return 1, err
+		if !validArg(err, q) {
+			return 1, errors.New("invalid entry for -qual \n" + usage)
 		}
 
 		qu = TextQualifier{
@@ -148,4 +141,11 @@ func run() (int, error) {
 	sw.Export(lines)
 
 	return 0, nil
+}
+
+func validArg(err error, arg string) bool {
+	if err != nil || arg == "" {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
* convert command line args to single character (except for -h or -help)
* improved error handling for empty args
* update README with usage examples with revised args