### PR TITLE
Add option for column filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Options:
   -s           delimiter (default: ',')
   -d           output delimiter (defaults to the value of sep)
   -a           <left>, <right>, <center> justification (default: left)
+  -c           output specific fields (default: all fields)
 ```
 
 _Specify your input file, output file, delimiter._

--- a/align.go
+++ b/align.go
@@ -26,6 +26,7 @@ type Alignable interface {
 	ColumnSize(int) int
 	UpdatePadding(PaddingOpts)
 	OutputSep(string)
+	filterColumns([]int)
 }
 
 // TextQualifier is used to configure the scanner to account for a text qualifier
@@ -48,6 +49,8 @@ type Aligner struct {
 	columnCounts map[int]int
 	txtq         TextQualifier
 	padOpts      PaddingOpts
+	filter       []int
+	filterLen    int
 }
 
 // NewAligner creates and initializes a ScanWriter with in and out as its initial Reader and Writer
@@ -181,14 +184,35 @@ func (a *Aligner) Export(lines []string) {
 
 		var columnNum int
 		for _, word := range words {
+
+			// start 48
+
+			// TODO: list will be 1 based
+			// list will already be sorted
+			// a list item can be hight than the existing number of fields and therefore ignored
+			// column list will be integers
+			if a.filterLen > 0 {
+				if !contains(a.filter, columnNum+1) {
+					columnNum++
+					if columnNum == len(words) {
+						a.W.WriteString("\n")
+					}
+					continue
+				}
+			}
+			// end 48
+
 			word = pad(word, columnNum, a.columnCounts[columnNum], a.padOpts)
 			columnNum++
 
 			// Do not add a delimiter to the last field
 			// This also properly aligns the output even if there are lines with a different number of fields
-			if columnNum == len(words) {
+			if a.filterLen > 0 && a.filter[a.filterLen-1] == columnNum {
 				a.W.WriteString(word + "\n")
-				continue
+				break
+			} else if columnNum == len(words) {
+				a.W.WriteString(word + "\n")
+				break
 			}
 			a.W.WriteString(word + a.sepOut)
 		}
@@ -272,4 +296,18 @@ func (a *Aligner) SplitWithQual(s, sep, qual string) []string {
 	}
 
 	return words
+}
+
+func (a *Aligner) filterColumns(c []int) {
+	a.filter = c
+	a.filterLen = len(c)
+}
+
+func contains(nums []int, num int) bool {
+	for _, v := range nums {
+		if v == num {
+			return true
+		}
+	}
+	return false
 }

--- a/align.go
+++ b/align.go
@@ -183,14 +183,8 @@ func (a *Aligner) Export(lines []string) {
 		words := a.SplitWithQual(line, a.sep, a.txtq.Qualifier)
 
 		var columnNum int
+		var tempColumn int // used for call to pad() to incorporate column filtering
 		for _, word := range words {
-
-			// start 48
-
-			// TODO: list will be 1 based
-			// list will already be sorted
-			// a list item can be hight than the existing number of fields and therefore ignored
-			// column list will be integers
 			if a.filterLen > 0 {
 				if !contains(a.filter, columnNum+1) {
 					columnNum++
@@ -200,10 +194,10 @@ func (a *Aligner) Export(lines []string) {
 					continue
 				}
 			}
-			// end 48
 
-			word = pad(word, columnNum, a.columnCounts[columnNum], a.padOpts)
+			word = pad(word, tempColumn, a.columnCounts[columnNum], a.padOpts)
 			columnNum++
+			tempColumn++
 
 			// Do not add a delimiter to the last field
 			// This also properly aligns the output even if there are lines with a different number of fields

--- a/main.go
+++ b/main.go
@@ -106,23 +106,23 @@ func run() (int, error) {
 		}
 	}
 
-	sw := NewAligner(input, output, *sFlag, qu)
+	aligner := NewAligner(input, output, *sFlag, qu)
 
 	switch *aFlag {
 	case "left":
-		sw.UpdatePadding(PaddingOpts{Justification: JustifyLeft})
+		aligner.UpdatePadding(PaddingOpts{Justification: JustifyLeft})
 	case "right":
-		sw.UpdatePadding(PaddingOpts{Justification: JustifyRight})
+		aligner.UpdatePadding(PaddingOpts{Justification: JustifyRight})
 	case "center":
-		sw.UpdatePadding(PaddingOpts{Justification: JustifyCenter})
+		aligner.UpdatePadding(PaddingOpts{Justification: JustifyCenter})
 	default:
-		sw.UpdatePadding(PaddingOpts{Justification: JustifyLeft})
+		aligner.UpdatePadding(PaddingOpts{Justification: JustifyLeft})
 	}
 
-	lines := sw.ColumnCounts()
+	lines := aligner.ColumnCounts()
 
-	sw.OutputSep(*dFlag)
-	sw.Export(lines)
+	aligner.OutputSep(*dFlag)
+	aligner.Export(lines)
 
 	return 0, nil
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 const usage = `Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a]
@@ -17,7 +20,8 @@ Options:
   -s           delimiter (default: ',')
   -d           output delimiter (defaults to the value of sep)
   -a           <left>, <right>, <center> justification (default: left)
-`
+  -c           output specific fields (default: all fields)
+  `
 
 func main() {
 	if retval, err := run(); err != nil {
@@ -40,6 +44,7 @@ func run() (int, error) {
 	sFlag := flag.String("s", ",", "")
 	dFlag := flag.String("d", "", "")
 	aFlag := flag.String("a", "left", "")
+	cFlag := flag.String("c", "", "")
 
 	flag.Parse()
 
@@ -106,6 +111,23 @@ func run() (int, error) {
 		}
 	}
 
+	var outColumns []int
+
+	if *cFlag != "" {
+		c := strings.Split(*cFlag, ",")
+		outColumns = make([]int, 0, len(c))
+
+		// validate specified field numbers and sort them
+		for _, v := range c {
+			num, err := strconv.Atoi(v)
+			if err != nil {
+				return 1, errors.New("make sure entry for -c are numbers (ie 1,2,5,7)")
+			}
+			outColumns = append(outColumns, num)
+		}
+		sort.Ints(outColumns)
+	}
+
 	aligner := NewAligner(input, output, *sFlag, qu)
 
 	switch *aFlag {
@@ -118,6 +140,8 @@ func run() (int, error) {
 	default:
 		aligner.UpdatePadding(PaddingOpts{Justification: JustifyLeft})
 	}
+
+	aligner.filterColumns(outColumns)
 
 	lines := aligner.ColumnCounts()
 

--- a/main.go
+++ b/main.go
@@ -123,7 +123,9 @@ func run() (int, error) {
 			if err != nil {
 				return 1, errors.New("make sure entry for -c are numbers (ie 1,2,5,7)")
 			}
-			outColumns = append(outColumns, num)
+			if num > 0 {
+				outColumns = append(outColumns, num)
+			}
 		}
 		sort.Ints(outColumns)
 	}


### PR DESCRIPTION
This enhancement closes #48 .

* `-c` flag added, which should be followed by a comma separated list of integers as the argument.
* List consists of the desired field numbers expected in the output.
* Indexing for the list starts at 1.  Any number in the list less than 1 will also be ignored.
* The list can be provided in any order, however the fields will still be output in the order in which they appear in the input (it might be cool to specify the order of the output fields, but that will have to be later).
* If a number in the list is larger than the number of fields in the row, it will be ignored.
* There will be no leading padding on the first field WRITTEN instead of the first field from the input (this avoids leading padding if the first field is excluded from the filter list)
* 