### PR TITLE
Issue39 alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Options:
   -d           output delimiter (defaults to the value of sep)
   -a           <left>, <right>, <center> justification (default: left)
   -c           output specific fields (default: all fields)
-  -v           override justification by column number (e.g. 2-center,5-right)
+  -i           override justification by column number (e.g. 2:center,5:right)
 ```
 
 _Specify your input file, output file, delimiter._

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ make release
 ### Usage - CLI examples
 
 ```
-Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a]
+Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a] [-c] [-i]
 Options:
   -h | --help  help
   -f           input file.  If not specified, pipe input to stdin

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Column filtering (specifiy output fields and optionally override the justificati
 $ cat file.csv | align -a right -c 1,3,5
 
 # output fields 1,2,3,7,8 with default justification (left) except for field 7, which is right justified
-$ cat file.csv | align -c 1,2,3,7,8 -v 1-right,7-center
+$ cat file.csv | align -c 1,2,3,7,8 -i 1:right,7:center
 
 #output all fields by default, with right justification, with overridden justification on certain columns
-$ cat file.csv | align -a right -v 1-center,5-left
+$ cat file.csv | align -a right -i 1:center,5:left
 ```
 
 Support for worldwide characters.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   -d           output delimiter (defaults to the value of sep)
   -a           <left>, <right>, <center> justification (default: left)
   -c           output specific fields (default: all fields)
+  -v           override justification by column number (e.g. 2-center,5-right)
 ```
 
 _Specify your input file, output file, delimiter._
@@ -66,6 +67,19 @@ $ echo "field1|field2\nValue1|Value2\nCoolValue1|CoolValue2|CoolValue3" | align 
 field1     | field2
 Value1     | Value2
 CoolValue1 | CoolValue2 | CoolValue3
+```
+
+Column filtering (specifiy output fields and optionally override the justification of the output fields).  This might be useful if you would like to display a dollar amount or number field differently.  The specified fields are indexed at 1.
+
+```sh
+# output fields 1,3,5 justified 'right'
+$ cat file.csv | align -a right -c 1,3,5
+
+# output fields 1,2,3,7,8 with default justification (left) except for field 7, which is right justified
+$ cat file.csv | align -c 1,2,3,7,8 -v 1-right,7-center
+
+#output all fields by default, with right justification, with overridden justification on certain columns
+$ cat file.csv | align -a right -v 1-center,5-left
 ```
 
 Support for worldwide characters.

--- a/align.go
+++ b/align.go
@@ -32,7 +32,8 @@ type TextQualifier struct {
 
 // PaddingOpts provides configurability for left/center/right justification and padding length
 type PaddingOpts struct {
-	Justification justification
+	Justification  justification
+	columnOverride map[int]justification //override the justification of specified columns
 }
 
 // Align scans input and writes output with aligned text
@@ -185,7 +186,18 @@ func (a *Align) export(lines []string) {
 				}
 			}
 
-			word = pad(word, tempColumn, a.columnCounts[columnNum], a.padOpts)
+			j := a.padOpts.Justification
+
+			// override justification for the specified columnNum in the key for the PaddingOpts.columnOverride map
+			if len(a.padOpts.columnOverride) > 0 {
+				for k, v := range a.padOpts.columnOverride {
+					if k == columnNum+1 {
+						j = v
+					}
+				}
+			}
+
+			word = pad(word, tempColumn, a.columnCounts[columnNum], j)
 			columnNum++
 			tempColumn++
 
@@ -205,10 +217,10 @@ func (a *Align) export(lines []string) {
 }
 
 // pad s based on the supplied PaddingOpts
-func pad(s string, columnNum, count int, p PaddingOpts) string {
+func pad(s string, columnNum, count int, j justification) string {
 	padLength := countPadding(s, count)
 
-	switch p.Justification {
+	switch j {
 	case JustifyLeft:
 		s = trailingPad(s, padLength)
 	case JustifyRight:

--- a/align_test.go
+++ b/align_test.go
@@ -256,7 +256,7 @@ var runCases = []struct {
 	dValue    string
 	aValue    string
 	cValue    string
-	vValue    string
+	iValue    string
 	shouldErr bool
 }{
 	{
@@ -268,15 +268,15 @@ var runCases = []struct {
 		shouldErr: true,
 	},
 	{
-		vValue:    "1-right,2-center",
+		iValue:    "1:right,2:center",
 		shouldErr: true,
 	},
 	{
-		vValue:    "1-left,2-,NaN-left",
+		iValue:    "1:left,2:,NaN:left",
 		shouldErr: true,
 	},
 	{
-		vValue:    "3-noexist",
+		iValue:    "3:noexist",
 		shouldErr: true,
 	},
 	{
@@ -371,7 +371,7 @@ func TestRun(t *testing.T) {
 		*aFlag = tt.aValue
 		*cFlag = tt.cValue
 		*qFlag = tt.qValue
-		*vFlag = tt.vValue
+		*iFlag = tt.iValue
 
 		code, _ := run()
 
@@ -486,11 +486,11 @@ func TestCountPadding(t *testing.T) {
 func BenchmarkColumnCounts(b *testing.B) {
 	input := `First,Middle,Last,Email,Region,City,Zip,Full_Name,First,Middle,Last,Email,Region,City,Zip,Full_Name,First,Middle,Last,Email,Region,City,Zip,Full_Name
 Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly        
-Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez         
+Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez
 Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly        
-Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez         
-Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly        
-Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez         
+Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez
+Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly
+Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez
 `
 
 	a := newAlign(strings.NewReader(input), os.Stdout, comma, TextQualifier{On: false})

--- a/align_test.go
+++ b/align_test.go
@@ -256,6 +256,7 @@ var runCases = []struct {
 	dValue    string
 	aValue    string
 	cValue    string
+	vValue    string
 	shouldErr bool
 }{
 	{
@@ -267,7 +268,27 @@ var runCases = []struct {
 		shouldErr: true,
 	},
 	{
+		vValue:    "1-right,2-center",
+		shouldErr: true,
+	},
+	{
+		vValue:    "1-left,2-,NaN-left",
+		shouldErr: true,
+	},
+	{
+		vValue:    "3-noexist",
+		shouldErr: true,
+	},
+	{
+		cValue:    "a2-right,NaN",
+		shouldErr: true,
+	},
+	{
 		cValue:    "1,2",
+		shouldErr: true,
+	},
+	{
+		cValue:    "1-left,2-right,3-center",
 		shouldErr: true,
 	},
 	{
@@ -350,6 +371,7 @@ func TestRun(t *testing.T) {
 		*aFlag = tt.aValue
 		*cFlag = tt.cValue
 		*qFlag = tt.qValue
+		*vFlag = tt.vValue
 
 		code, _ := run()
 
@@ -414,7 +436,7 @@ func TestSplit(t *testing.T) {
 
 func TestPad(t *testing.T) {
 	for _, tt := range paddingCases {
-		got := pad(tt.input, 1, tt.columnCount, tt.po)
+		got := pad(tt.input, 1, tt.columnCount, tt.po.Justification)
 
 		if len(got) != tt.expected {
 			t.Fatalf("pad(%v) =%v; want %v", tt.input, got, tt.expected)

--- a/align_test.go
+++ b/align_test.go
@@ -235,6 +235,12 @@ var exportCases = []struct {
 	{
 		strings.NewReader("first,middle,last"),
 		bytes.NewBufferString(""),
+		[]int{1, 4},
+		0,
+	},
+	{
+		strings.NewReader("first,middle,last"),
+		bytes.NewBufferString(""),
 		nil,
 		0,
 	},

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-const usage = `Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a]
+const usage = `Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a] [-c] [-i]
 Options:
   -h | --help  help
   -f           input file.  If not specified, pipe input to stdin

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ Options:
   -d           output delimiter (defaults to the value of sep)
   -a           <left>, <right>, <center> justification (default: left)
   -c           output specific fields (default: all fields)
-  -v           override justification by column number (e.g. 2-center,5-right)
+  -i           override justification by column number (e.g. 2:center,5:right)
   `
 
 func main() {
@@ -40,7 +40,7 @@ var sFlag *string
 var dFlag *string
 var aFlag *string
 var cFlag *string
-var vFlag *string
+var iFlag *string
 
 func init() {
 	flag.Usage = func() {
@@ -56,7 +56,7 @@ func init() {
 	dFlag = flag.String("d", "", "")
 	aFlag = flag.String("a", "left", "")
 	cFlag = flag.String("c", "", "")
-	vFlag = flag.String("v", "", "")
+	iFlag = flag.String("i", "", "")
 }
 
 func run() (int, error) {
@@ -84,17 +84,17 @@ func run() (int, error) {
 	var outColumns []int
 	var justifyOverrides = make(map[int]justification)
 
-	if *vFlag != "" {
-		c := strings.Split(*vFlag, ",")
+	if *iFlag != "" {
+		c := strings.Split(*iFlag, ",")
 
 		for _, v := range c {
-			if strings.HasSuffix(v, "-right") || strings.HasSuffix(v, "-center") || strings.HasSuffix(v, "-left") {
-				overrides := strings.Split(v, "-")
+			if strings.HasSuffix(v, ":right") || strings.HasSuffix(v, ":center") || strings.HasSuffix(v, ":left") {
+				overrides := strings.Split(v, ":")
 				v = overrides[0]
 
 				num, err := strconv.Atoi(v)
 				if err != nil {
-					return 1, errors.New("make sure entry for -v are numbers with a justification separated by '-' (ie 1-right,3-center)")
+					return 1, errors.New("make sure entry for -v are numbers with a justification separated by ':' (ie 1-right,3-center)")
 				}
 
 				switch overrides[1] {
@@ -109,7 +109,7 @@ func run() (int, error) {
 		}
 
 		if len(justifyOverrides) < 1 {
-			return 1, errors.New("make sure entry for -v are numbers with a justification separated by '-' (ie 1-right,3-center)")
+			return 1, errors.New("make sure entry for -v are numbers with a justification separated by ':' (ie 1:right,3:center)")
 		}
 	}
 


### PR DESCRIPTION
This resolves #39 (sort of).  

Instead of a flag that switches the justification of a numeric field (and correctly detecting the numeric field) I added a `-v` flag.  This allows the user to set column overrides for the justification for any field that they specify.  This example aligns all fields to the right, but aligns the specified fields differently with the argument to `-v`:

`align -f input.csv -a right -v 1-left,5-center`

* adding a map to the `PaddingOpts` struct which will get checked in the `export()` function.
* updating README with usage, and examples
* updating tests