### PR TITLE
Configurable padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ first  😮 last     😮 email
 Hector 😮 Gonzalez 😮 h.g@nothing.com
 ```
 
+Add additional padding if desired with the `-p` flag.  Default is 1 space.  If less than 0, then no additional padding will be applied.
+```
+# padding of 4 spaces surrounding the delimiter.
+align -p 4
+```
+
 ### Contributions
 
 If you have suggestions or discover a bug, please open an issue.  If you think you can make the fix, please use the Fork / Pull Request on your feature branch approach.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ first  😮 last     😮 email
 Hector 😮 Gonzalez 😮 h.g@nothing.com
 ```
 
-Add additional padding if desired with the `-p` flag.  Default is 1 space.  If less than 0, then no additional padding will be applied.
+Add additional padding if desired with the `-p` flag.  Default is 1 space, and 0 will output with no additional padding.  If the value supplied is less than 0, then the behavior will be as if it were set to 0 and no padding will be applied.
 ```
 # padding of 4 spaces surrounding the delimiter.
 align -p 4

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ make release
 ### Usage - CLI examples
 
 ```
-Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a] [-c] [-i]
+Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a] [-c] [-i] [-p]
 Options:
   -h | --help  help
   -f           input file.  If not specified, pipe input to stdin
@@ -46,6 +46,7 @@ Options:
   -a           <left>, <right>, <center> justification (default: left)
   -c           output specific fields (default: all fields)
   -i           override justification by column number (e.g. 2:center,5:right)
+  -p           extra padding surrounding delimiter
 ```
 
 _Specify your input file, output file, delimiter._

--- a/align.go
+++ b/align.go
@@ -8,8 +8,6 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
-const singleSpace = " "
-
 // Justification
 type Justification byte
 
@@ -35,6 +33,7 @@ type TextQualifier struct {
 type PaddingOpts struct {
 	Justification  Justification
 	ColumnOverride map[int]Justification //override the Justification of specified columns
+	Surround       int                   // additional padding surrounding separator
 }
 
 // Align scans input and writes output with aligned text
@@ -64,7 +63,9 @@ func NewAlign(in io.Reader, out io.Writer, sep string, qu TextQualifier) *Align 
 		columnCounts: make(map[int]int),
 		txtq:         qu,
 		padOpts: PaddingOpts{
-			Justification: JustifyLeft, // default
+			//defaults
+			Justification: JustifyLeft,
+			Surround:      1,
 		},
 	}
 }
@@ -171,6 +172,16 @@ func (a *Align) columnLength() []string {
 
 // export will pad each field in lines based on the Aligner's column counts
 func (a *Align) export(lines []string) {
+	if a.padOpts.Surround < 0 {
+		a.padOpts.Surround = 0
+	}
+
+	surround := make([]byte, 0, a.padOpts.Surround)
+
+	for i := 0; i < a.padOpts.Surround; i++ {
+		surround = append(surround, ' ')
+	}
+
 	for _, line := range lines {
 		words := a.splitWithQual(line, a.sep, a.txtq.Qualifier)
 
@@ -198,7 +209,7 @@ func (a *Align) export(lines []string) {
 				}
 			}
 
-			word = pad(word, tempColumn, a.columnCounts[columnNum], j)
+			word = pad(word, tempColumn, a.columnCounts[columnNum], j, string(surround))
 			columnNum++
 			tempColumn++
 
@@ -218,7 +229,7 @@ func (a *Align) export(lines []string) {
 }
 
 // pad s based on the supplied PaddingOpts
-func pad(s string, columnNum, count int, j Justification) string {
+func pad(s string, columnNum, count int, j Justification, sur string) string {
 	padLength := countPadding(s, count)
 
 	switch j {
@@ -235,11 +246,10 @@ func pad(s string, columnNum, count int, j Justification) string {
 		}
 	}
 
-	// at least one space to pad every field after the delimiter for readability
 	if columnNum > 0 {
-		s = singleSpace + s
+		s = sur + s
 	}
-	s = s + singleSpace
+	s = s + sur
 
 	return s
 }
@@ -292,7 +302,7 @@ func (a *Align) splitWithQual(s, sep, qual string) []string {
 	return words
 }
 
-// FilterColumns
+// FilterColumns sets which column numbers should be output.
 func (a *Align) FilterColumns(c []int) {
 	a.filter = c
 	a.filterLen = len(c)

--- a/align.go
+++ b/align.go
@@ -33,7 +33,7 @@ type TextQualifier struct {
 type PaddingOpts struct {
 	Justification  Justification
 	ColumnOverride map[int]Justification //override the Justification of specified columns
-	Surround       int                   // additional padding surrounding separator
+	Pad            int                   // padding surrounding the separator
 }
 
 // Align scans input and writes output with aligned text
@@ -65,7 +65,7 @@ func NewAlign(in io.Reader, out io.Writer, sep string, qu TextQualifier) *Align 
 		padOpts: PaddingOpts{
 			//defaults
 			Justification: JustifyLeft,
-			Surround:      1,
+			Pad:           1,
 		},
 	}
 }
@@ -172,14 +172,14 @@ func (a *Align) columnLength() []string {
 
 // export will pad each field in lines based on the Aligner's column counts
 func (a *Align) export(lines []string) {
-	if a.padOpts.Surround < 0 {
-		a.padOpts.Surround = 0
+	if a.padOpts.Pad < 0 {
+		a.padOpts.Pad = 0
 	}
 
-	surround := make([]byte, 0, a.padOpts.Surround)
+	p := make([]byte, 0, a.padOpts.Pad)
 
-	for i := 0; i < a.padOpts.Surround; i++ {
-		surround = append(surround, ' ')
+	for i := 0; i < a.padOpts.Pad; i++ {
+		p = append(p, ' ')
 	}
 
 	for _, line := range lines {
@@ -209,7 +209,7 @@ func (a *Align) export(lines []string) {
 				}
 			}
 
-			word = pad(word, tempColumn, a.columnCounts[columnNum], j, string(surround))
+			word = applyPadding(word, tempColumn, a.columnCounts[columnNum], j, string(p))
 			columnNum++
 			tempColumn++
 
@@ -229,7 +229,7 @@ func (a *Align) export(lines []string) {
 }
 
 // pad s based on the supplied PaddingOpts
-func pad(s string, columnNum, count int, j Justification, sur string) string {
+func applyPadding(s string, columnNum, count int, j Justification, pad string) string {
 	padLength := countPadding(s, count)
 
 	switch j {
@@ -246,10 +246,12 @@ func pad(s string, columnNum, count int, j Justification, sur string) string {
 		}
 	}
 
-	if columnNum > 0 {
-		s = sur + s
+	if len(pad) > 0 {
+		if columnNum > 0 {
+			s = pad + s
+		}
+		s = s + pad
 	}
-	s = s + sur
 
 	return s
 }

--- a/align_test.go
+++ b/align_test.go
@@ -153,25 +153,25 @@ var paddingCases = []struct {
 	{
 		"Go",
 		8,
-		PaddingOpts{Justification: JustifyLeft},
+		PaddingOpts{Justification: JustifyLeft, Surround: 1},
 		10,
 	},
 	{
 		"Go",
 		8,
-		PaddingOpts{Justification: JustifyCenter},
+		PaddingOpts{Justification: JustifyCenter, Surround: 1},
 		10,
 	},
 	{
 		"Go",
 		4,
-		PaddingOpts{Justification: JustifyCenter},
+		PaddingOpts{Justification: JustifyCenter, Surround: 1},
 		6,
 	},
 	{
 		"Go",
 		8,
-		PaddingOpts{Justification: JustifyRight},
+		PaddingOpts{Justification: JustifyRight, Surround: 1},
 		10,
 	},
 }
@@ -419,7 +419,7 @@ func TestSplit(t *testing.T) {
 // TestPad
 func TestPad(t *testing.T) {
 	for _, tt := range paddingCases {
-		got := pad(tt.input, 1, tt.columnCount, tt.po.Justification)
+		got := pad(tt.input, 1, tt.columnCount, tt.po.Justification, " ")
 
 		if len(got) != tt.expected {
 			t.Fatalf("pad(%v) =%v; want %v", tt.input, got, tt.expected)
@@ -477,7 +477,7 @@ func TestGenFieldLen(t *testing.T) {
 	got := genFieldLen(s, comma, comma)
 	expected := 2
 	if got != expected {
-		t.Fatalf("genFieldLen(%s, ", ", ", ") = %v; want %v", s, got, expected)
+		t.Fatalf("genFieldLen(%v, %v, %v) = %v; want %v", s, comma, comma, got, expected)
 	}
 }
 

--- a/align_test.go
+++ b/align_test.go
@@ -153,25 +153,25 @@ var paddingCases = []struct {
 	{
 		"Go",
 		8,
-		PaddingOpts{Justification: JustifyLeft, Surround: 1},
+		PaddingOpts{Justification: JustifyLeft, Pad: 1},
 		10,
 	},
 	{
 		"Go",
 		8,
-		PaddingOpts{Justification: JustifyCenter, Surround: 1},
+		PaddingOpts{Justification: JustifyCenter, Pad: 1},
 		10,
 	},
 	{
 		"Go",
 		4,
-		PaddingOpts{Justification: JustifyCenter, Surround: 1},
+		PaddingOpts{Justification: JustifyCenter, Pad: 1},
 		6,
 	},
 	{
 		"Go",
 		8,
-		PaddingOpts{Justification: JustifyRight, Surround: 1},
+		PaddingOpts{Justification: JustifyRight, Pad: 1},
 		10,
 	},
 }
@@ -419,7 +419,7 @@ func TestSplit(t *testing.T) {
 // TestPad
 func TestPad(t *testing.T) {
 	for _, tt := range paddingCases {
-		got := pad(tt.input, 1, tt.columnCount, tt.po.Justification, " ")
+		got := applyPadding(tt.input, 1, tt.columnCount, tt.po.Justification, " ")
 
 		if len(got) != tt.expected {
 			t.Fatalf("pad(%v) =%v; want %v", tt.input, got, tt.expected)

--- a/align_test.go
+++ b/align_test.go
@@ -159,19 +159,19 @@ var paddingCases = []struct {
 	{
 		"Go",
 		8,
-		PaddingOpts{Justification: JustifyCenter, Pad: 1},
+		PaddingOpts{Justification: JustifyCenter, Pad: 0},
 		10,
 	},
 	{
 		"Go",
 		4,
-		PaddingOpts{Justification: JustifyCenter, Pad: 1},
+		PaddingOpts{Justification: JustifyCenter, Pad: -1},
 		6,
 	},
 	{
 		"Go",
 		8,
-		PaddingOpts{Justification: JustifyRight, Pad: 1},
+		PaddingOpts{Justification: JustifyRight, Pad: 2},
 		10,
 	},
 }
@@ -218,31 +218,41 @@ var exportCases = []struct {
 	input          io.Reader
 	output         io.Writer
 	outColumns     []int
+	overrides      map[int]Justification
+	pad            int
 	numOfDelimiter int
 }{
 	{
 		strings.NewReader("one,two,three\nfour,five,six"),
 		bytes.NewBufferString(""),
 		[]int{1},
+		map[int]Justification{1: JustifyRight},
+		1,
 		1,
 	},
 	{
 		strings.NewReader("first,middle,last"),
 		bytes.NewBufferString(""),
 		[]int{1, 3},
-		0,
+		map[int]Justification{1: JustifyRight},
+		-1,
+		1,
 	},
 	{
 		strings.NewReader("first,middle,last"),
 		bytes.NewBufferString(""),
 		[]int{1, 4},
+		map[int]Justification{1: JustifyRight},
+		0,
 		0,
 	},
 	{
 		strings.NewReader("first,middle,last"),
 		bytes.NewBufferString(""),
 		nil,
-		0,
+		map[int]Justification{1: JustifyRight},
+		1,
+		2,
 	},
 }
 
@@ -358,6 +368,38 @@ var updatePaddingCases = []struct {
 	},
 }
 
+var genFieldLenCases = []struct {
+	input    string
+	sep      string
+	qual     string
+	expected int // len of first field for the input
+}{
+	{
+		"as,df,q,wer,1234,zxc,v",
+		",",
+		"",
+		2,
+	},
+	{
+		"hello|hithere",
+		"|",
+		"",
+		5,
+	},
+	{
+		"hello|\"hith|ere\"",
+		"|",
+		"\"",
+		5,
+	},
+	{
+		"'hello'",
+		",",
+		"'",
+		7,
+	},
+}
+
 // TestUpdatePadding
 func TestUpdatePadding(t *testing.T) {
 	for _, tt := range updatePaddingCases {
@@ -398,6 +440,7 @@ func TestOutputSep(t *testing.T) {
 func TestColumnFilter(t *testing.T) {
 	for _, tt := range exportCases {
 		a := NewAlign(tt.input, tt.output, comma, TextQualifier{})
+		a.UpdatePadding(PaddingOpts{ColumnOverride: tt.overrides, Pad: tt.pad})
 		a.FilterColumns(tt.outColumns)
 
 		a.Align()
@@ -472,12 +515,13 @@ func TestCountPadding(t *testing.T) {
 
 // TestGenFieldLen
 func TestGenFieldLen(t *testing.T) {
-	s := "as,df,q,wer,1234,zxc,v"
-	comma := ","
-	got := genFieldLen(s, comma, comma)
-	expected := 2
-	if got != expected {
-		t.Fatalf("genFieldLen(%v, %v, %v) = %v; want %v", s, comma, comma, got, expected)
+
+	for _, tt := range genFieldLenCases {
+		got := genFieldLen(tt.input, tt.sep, tt.qual)
+
+		if got != tt.expected {
+			t.Fatalf("genFieldLen(%v, %v, %v) = %v; want %v", tt.input, tt.sep, tt.qual, got, tt.expected)
+		}
 	}
 }
 

--- a/cmd/align/main.go
+++ b/cmd/align/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Guitarbum722/align"
 )
 
-const usage = `Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a] [-c] [-i]
+const usage = `Usage: align [-h] [-f] [-o] [-q] [-s] [-d] [-a] [-c] [-i] [-p]
 Options:
   -h | --help  help
   -f           input file.  If not specified, pipe input to stdin
@@ -24,6 +24,7 @@ Options:
   -a           <left>, <right>, <center> justification (default: left)
   -c           output specific fields (default: all fields)
   -i           override justification by column number (e.g. 2:center,5:right)
+  -p           extra padding surrounding delimiter
   `
 
 var (
@@ -37,6 +38,7 @@ var (
 	aFlag    *string
 	cFlag    *string
 	iFlag    *string
+	pFlag    *int
 )
 
 func main() {
@@ -61,6 +63,7 @@ func init() {
 	aFlag = flag.String("a", "left", "")
 	cFlag = flag.String("c", "", "")
 	iFlag = flag.String("i", "", "")
+	pFlag = flag.Int("p", 1, "")
 }
 
 func run() (int, error) {
@@ -180,13 +183,29 @@ func run() (int, error) {
 
 	switch *aFlag {
 	case "left":
-		aligner.UpdatePadding(align.PaddingOpts{Justification: align.JustifyLeft, ColumnOverride: justifyOverrides})
+		aligner.UpdatePadding(align.PaddingOpts{
+			Justification:  align.JustifyLeft,
+			ColumnOverride: justifyOverrides,
+			Surround:       *pFlag,
+		})
 	case "right":
-		aligner.UpdatePadding(align.PaddingOpts{Justification: align.JustifyRight, ColumnOverride: justifyOverrides})
+		aligner.UpdatePadding(align.PaddingOpts{
+			Justification:  align.JustifyRight,
+			ColumnOverride: justifyOverrides,
+			Surround:       *pFlag,
+		})
 	case "center":
-		aligner.UpdatePadding(align.PaddingOpts{Justification: align.JustifyCenter, ColumnOverride: justifyOverrides})
+		aligner.UpdatePadding(align.PaddingOpts{
+			Justification:  align.JustifyCenter,
+			ColumnOverride: justifyOverrides,
+			Surround:       *pFlag,
+		})
 	default:
-		aligner.UpdatePadding(align.PaddingOpts{Justification: align.JustifyLeft, ColumnOverride: justifyOverrides})
+		aligner.UpdatePadding(align.PaddingOpts{
+			Justification:  align.JustifyLeft,
+			ColumnOverride: justifyOverrides,
+			Surround:       *pFlag,
+		})
 	}
 	aligner.FilterColumns(outColumns)
 	aligner.OutputSep(*dFlag)

--- a/cmd/align/main.go
+++ b/cmd/align/main.go
@@ -186,25 +186,25 @@ func run() (int, error) {
 		aligner.UpdatePadding(align.PaddingOpts{
 			Justification:  align.JustifyLeft,
 			ColumnOverride: justifyOverrides,
-			Surround:       *pFlag,
+			Pad:            *pFlag,
 		})
 	case "right":
 		aligner.UpdatePadding(align.PaddingOpts{
 			Justification:  align.JustifyRight,
 			ColumnOverride: justifyOverrides,
-			Surround:       *pFlag,
+			Pad:            *pFlag,
 		})
 	case "center":
 		aligner.UpdatePadding(align.PaddingOpts{
 			Justification:  align.JustifyCenter,
 			ColumnOverride: justifyOverrides,
-			Surround:       *pFlag,
+			Pad:            *pFlag,
 		})
 	default:
 		aligner.UpdatePadding(align.PaddingOpts{
 			Justification:  align.JustifyLeft,
 			ColumnOverride: justifyOverrides,
-			Surround:       *pFlag,
+			Pad:            *pFlag,
 		})
 	}
 	aligner.FilterColumns(outColumns)


### PR DESCRIPTION
Closes #30 

* add `-p` flag to specify number of spaces to pad each column around the separator/delimiter
* consumer of the lib can set `Surround` on `Align.PaddingOpts`.
* default is *1* space for padding, which is the current behavior anyway.

Since the other features in #30 are either out of scope or covered by the current justification features, we will wait to see if any use cases present themselves for additional functionality.