### PR TITLE
Issue67 reduce allocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ bin/*
 *.swp
 *.swo
 
+
+align

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ os:
   - linux
   - freebsd
   - osx
-  - windows
 before_install:
   - go get github.com/mattn/goveralls
 notifications:

--- a/align.go
+++ b/align.go
@@ -248,7 +248,7 @@ func (a *Align) export() {
 			padLength := countPadding(word, a.columnCounts[columnNum])
 			// a.padder.Grow(padLength + len(word) + (len(surroundingPad) * 2)) // TODO: might be able to do this once
 
-			word = applyPadding(a.padder, word, string(surroundingPad), tempColumn, padLength, j)
+			paddedWord := applyPadding(a.padder, word, string(surroundingPad), tempColumn, padLength, j)
 
 			a.padder.Reset() // empty the buffer for the next iteration.
 
@@ -258,13 +258,13 @@ func (a *Align) export() {
 			// Do not add a delimiter to the last field
 			// This also properly aligns the output even if there are lines with a different number of fields
 			if a.filterLen > 0 && a.filter[a.filterLen-1] == columnNum {
-				a.writer.WriteString(word + "\n")
+				a.writer.WriteString(paddedWord + "\n")
 				break
-			} else if columnNum == len(words) {
-				a.writer.WriteString(word + "\n")
+			} else if columnNum == len(paddedWord) {
+				a.writer.WriteString(paddedWord + "\n")
 				break
 			}
-			a.writer.WriteString(word + a.sepOut)
+			a.writer.WriteString(paddedWord + a.sepOut)
 		}
 	}
 	a.writer.Flush()

--- a/align.go
+++ b/align.go
@@ -268,6 +268,12 @@ func (a *Align) export() {
 	a.writer.Flush()
 }
 
+func fillWithPadding(padder Padder, length int) {
+	for i := 0; i < length; i++ {
+		padder.WriteByte(padchar)
+	}
+}
+
 // applyPadding rebuilds word by adding padding appropriately based on the
 // desired justification, the overall padding length and the supplied surrounding
 // padding string.
@@ -283,29 +289,19 @@ func applyPadding(padder Padder, original, surroundingPad string, columnNum, pad
 	switch just {
 	case JustifyLeft:
 		padder.WriteString(original)
-		for i := 0; i < padLength; i++ {
-			padder.WriteByte(padchar)
-		}
+		fillWithPadding(padder, padLength)
 	case JustifyRight:
-		for i := 0; i < padLength; i++ {
-			padder.WriteByte(padchar)
-		}
+		fillWithPadding(padder, padLength)
 		padder.WriteString(original)
 	case JustifyCenter:
 		// not much of a point to 'center' justification with such a small padding; default it if <= 2.
 		if padLength > 2 {
-			for i := 0; i < (padLength - (padLength / 2)); i++ {
-				padder.WriteByte(padchar)
-			}
+			fillWithPadding(padder, (padLength - (padLength / 2)))
 			padder.WriteString(original)
-			for i := 0; i < (padLength / 2); i++ {
-				padder.WriteByte(padchar)
-			}
+			fillWithPadding(padder, padLength/2)
 		} else {
 			padder.WriteString(original)
-			for i := 0; i < padLength; i++ {
-				padder.WriteByte(padchar)
-			}
+			fillWithPadding(padder, padLength)
 		}
 	}
 

--- a/align.go
+++ b/align.go
@@ -224,7 +224,9 @@ func (a *Align) export(lines []string) {
 	a.writer.Flush()
 }
 
-// pad s based on the supplied PaddingOpts.
+// applyPadding rebuilds word by adding padding appropriately based on the
+// desired justification, the overall column count and the supplied surrounding
+// padding string.
 func applyPadding(word string, columnNum, count int, just Justification, surroundingPad string) string {
 	padLength := countPadding(word, count)
 
@@ -250,13 +252,23 @@ func applyPadding(word string, columnNum, count int, just Justification, surroun
 		}
 		sb.WriteString(word)
 	case JustifyCenter:
+		// not much of a point to 'center' justification with such a small padding; default it if <= 2.
 		if padLength > 2 {
-			trailingPad(&sb, padLength/2)
+			for i := 0; i < (padLength - (padLength / 2)); i++ {
+				sb.WriteByte(' ')
+			}
 			sb.WriteString(word)
-			leadingPad(&sb, padLength-(padLength/2))
+			for i := 0; i < (padLength / 2); i++ {
+				sb.WriteByte(' ')
+			}
+			// trailingPad(&sb, padLength/2)
+			// sb.WriteString(word)
+			// leadingPad(&sb, padLength-(padLength/2))
 		} else {
 			sb.WriteString(word)
-			trailingPad(&sb, padLength)
+			for i := 0; i < padLength; i++ {
+				sb.WriteByte(' ')
+			}
 		}
 	}
 

--- a/align.go
+++ b/align.go
@@ -214,7 +214,6 @@ func (a *Align) export() {
 	}
 
 	surroundingPad := make([]byte, 0, a.padOpts.Pad)
-
 	for i := 0; i < a.padOpts.Pad; i++ {
 		surroundingPad = append(surroundingPad, padchar)
 	}
@@ -278,7 +277,6 @@ func fillWithPadding(padder Padder, length int) {
 // desired justification, the overall padding length and the supplied surrounding
 // padding string.
 func applyPadding(padder Padder, original, surroundingPad string, columnNum, padLength int, just Justification) []byte {
-
 	// add surrounding pad to beginning of column (except for the 1st column)
 	if len(surroundingPad) > 0 {
 		if columnNum > 0 {

--- a/align.go
+++ b/align.go
@@ -2,6 +2,7 @@ package align
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -58,7 +59,7 @@ type PadGrower interface {
 // fieldPad ructs the contents of a field
 // with padding.
 type fieldPad struct {
-	strings.Builder
+	bytes.Buffer
 }
 
 // Align scans input and writes output with aligned text.
@@ -245,7 +246,7 @@ func (a *Align) export() {
 			}
 
 			padLength := countPadding(word, a.columnCounts[columnNum])
-			a.padder.Grow(padLength + len(word) + (len(surroundingPad) * 2)) // TODO: might be able to do this once
+			// a.padder.Grow(padLength + len(word) + (len(surroundingPad) * 2)) // TODO: might be able to do this once
 
 			word = applyPadding(a.padder, word, string(surroundingPad), tempColumn, padLength, j)
 

--- a/align.go
+++ b/align.go
@@ -231,6 +231,7 @@ func applyPadding(word string, columnNum, count int, just Justification, surroun
 	var sb strings.Builder
 	sb.Grow(padLength + len(word) + (len(surroundingPad) * 2))
 
+	// add surrounding pad to beginning of column (except for the 1st column)
 	if len(surroundingPad) > 0 {
 		if columnNum > 0 {
 			sb.WriteString(surroundingPad)
@@ -259,10 +260,9 @@ func applyPadding(word string, columnNum, count int, just Justification, surroun
 		}
 	}
 
+	// add surrounding pad to end of column
 	if len(surroundingPad) > 0 {
-		if columnNum > 0 {
-			sb.WriteString(surroundingPad)
-		}
+		sb.WriteString(surroundingPad)
 	}
 	return sb.String()
 }

--- a/align.go
+++ b/align.go
@@ -261,9 +261,6 @@ func applyPadding(word string, columnNum, count int, just Justification, surroun
 			for i := 0; i < (padLength / 2); i++ {
 				sb.WriteByte(' ')
 			}
-			// trailingPad(&sb, padLength/2)
-			// sb.WriteString(word)
-			// leadingPad(&sb, padLength-(padLength/2))
 		} else {
 			sb.WriteString(word)
 			for i := 0; i < padLength; i++ {

--- a/align.go
+++ b/align.go
@@ -34,8 +34,10 @@ type PaddingOpts struct {
 }
 
 // Grower grows by the given number of bytes n.
+// Reset will set the Grower to 0.
 type Grower interface {
 	Grow(n int)
+	Reset()
 }
 
 // Padder builds a string and can return its string value.
@@ -243,9 +245,12 @@ func (a *Align) export() {
 			}
 
 			padLength := countPadding(word, a.columnCounts[columnNum])
-			a.padder.Grow(padLength + len(word) + (len(surroundingPad) * 2))
+			a.padder.Grow(padLength + len(word) + (len(surroundingPad) * 2)) // TODO: might be able to do this once
 
 			word = applyPadding(a.padder, word, string(surroundingPad), tempColumn, padLength, j)
+
+			a.padder.Reset() // empty the buffer for the next iteration.
+
 			columnNum++
 			tempColumn++
 

--- a/align.go
+++ b/align.go
@@ -47,6 +47,7 @@ type Padder interface {
 	fmt.Stringer
 	WriteByte(c byte) error
 	WriteString(s string) (int, error)
+	Bytes() []byte
 }
 
 // PadGrower makes a string with the ability to
@@ -255,14 +256,13 @@ func (a *Align) export() {
 
 			// Do not add a delimiter to the last field
 			// This also properly aligns the output even if there are lines with a different number of fields
-			if a.filterLen > 0 && a.filter[a.filterLen-1] == columnNum {
-				a.writer.WriteString(paddedWord + "\n")
-				break
-			} else if columnNum == len(paddedWord) {
-				a.writer.WriteString(paddedWord + "\n")
+			if a.filterLen > 0 && a.filter[a.filterLen-1] == columnNum || columnNum == len(paddedWord) {
+				a.writer.Write(paddedWord)
+				a.writer.WriteByte('\n')
 				break
 			}
-			a.writer.WriteString(paddedWord + a.sepOut)
+			a.writer.Write(paddedWord)
+			a.writer.WriteString(a.sepOut)
 		}
 	}
 	a.writer.Flush()
@@ -277,7 +277,7 @@ func fillWithPadding(padder Padder, length int) {
 // applyPadding rebuilds word by adding padding appropriately based on the
 // desired justification, the overall padding length and the supplied surrounding
 // padding string.
-func applyPadding(padder Padder, original, surroundingPad string, columnNum, padLength int, just Justification) string {
+func applyPadding(padder Padder, original, surroundingPad string, columnNum, padLength int, just Justification) []byte {
 
 	// add surrounding pad to beginning of column (except for the 1st column)
 	if len(surroundingPad) > 0 {
@@ -309,7 +309,7 @@ func applyPadding(padder Padder, original, surroundingPad string, columnNum, pad
 	if len(surroundingPad) > 0 {
 		padder.WriteString(surroundingPad)
 	}
-	return padder.String()
+	return padder.Bytes()
 }
 
 // determines the length of the padding needed.

--- a/align.go
+++ b/align.go
@@ -246,8 +246,6 @@ func (a *Align) export() {
 			}
 
 			padLength := countPadding(word, a.columnCounts[columnNum])
-			// a.padder.Grow(padLength + len(word) + (len(surroundingPad) * 2)) // TODO: might be able to do this once
-
 			paddedWord := applyPadding(a.padder, word, string(surroundingPad), tempColumn, padLength, j)
 
 			a.padder.Reset() // empty the buffer for the next iteration.

--- a/align_test.go
+++ b/align_test.go
@@ -148,30 +148,35 @@ var paddingCases = []struct {
 	input       string
 	columnCount int
 	po          PaddingOpts
+	pad         Padder
 	expected    int
 }{
 	{
 		"Go",
 		8,
 		PaddingOpts{Justification: JustifyLeft, Pad: 1},
+		&fieldPad{},
 		10,
 	},
 	{
 		"Go",
 		8,
 		PaddingOpts{Justification: JustifyCenter, Pad: 0},
+		&fieldPad{},
 		10,
 	},
 	{
 		"Go",
 		4,
 		PaddingOpts{Justification: JustifyCenter, Pad: -1},
+		&fieldPad{},
 		6,
 	},
 	{
 		"Go",
 		8,
 		PaddingOpts{Justification: JustifyRight, Pad: 2},
+		&fieldPad{},
 		10,
 	},
 }
@@ -461,11 +466,12 @@ func TestSplit(t *testing.T) {
 
 // TestPad
 func TestPad(t *testing.T) {
-	for _, tt := range paddingCases[:1] {
-		got := applyPadding(tt.input, 1, tt.columnCount, tt.po.Justification, " ")
+	for _, tt := range paddingCases {
+		padLen := countPadding(tt.input, tt.columnCount)
+		got := applyPadding(tt.pad, tt.input, " ", 1, padLen, tt.po.Justification)
 
 		if len(got) != tt.expected {
-			t.Fatalf("pad(%v) =%v; want %v", tt.input, len(got), tt.expected)
+			t.Fatalf("pad(%v) =%v; want %v", tt.input, got, tt.expected)
 		}
 	}
 }
@@ -586,12 +592,12 @@ func BenchmarkExport(b *testing.B) {
 	input := "First,Middle,Last,Email,Region,City,Zip,Full_Name"
 
 	a := NewAlign(strings.NewReader(input), &bytes.Buffer{}, comma, TextQualifier{On: false})
-	lines := a.columnLength()
+	a.columnLength()
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		a.export(lines)
+		a.export()
 	}
 }

--- a/align_test.go
+++ b/align_test.go
@@ -461,11 +461,11 @@ func TestSplit(t *testing.T) {
 
 // TestPad
 func TestPad(t *testing.T) {
-	for _, tt := range paddingCases {
+	for _, tt := range paddingCases[:1] {
 		got := applyPadding(tt.input, 1, tt.columnCount, tt.po.Justification, " ")
 
 		if len(got) != tt.expected {
-			t.Fatalf("pad(%v) =%v; want %v", tt.input, got, tt.expected)
+			t.Fatalf("pad(%v) =%v; want %v", tt.input, len(got), tt.expected)
 		}
 	}
 }

--- a/align_test.go
+++ b/align_test.go
@@ -544,7 +544,7 @@ Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reil
 Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez
 `
 
-	a := NewAlign(strings.NewReader(input), os.Stdout, comma, TextQualifier{On: false})
+	a := NewAlign(strings.NewReader(input), &bytes.Buffer{}, comma, TextQualifier{On: false})
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -558,7 +558,7 @@ Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivi
 func BenchmarkSplitWithQual(b *testing.B) {
 	input := "First,\"Middle, name\",Last,Email,Region,City,Zip,Full_Name"
 
-	a := NewAlign(strings.NewReader(input), os.Stdout, comma, TextQualifier{On: true, Qualifier: "\""})
+	a := NewAlign(strings.NewReader(input), &bytes.Buffer{}, comma, TextQualifier{On: true, Qualifier: "\""})
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -572,12 +572,26 @@ func BenchmarkSplitWithQual(b *testing.B) {
 func BenchmarkSplitWithQualNoQual(b *testing.B) {
 	input := "First,Middle,Last,Email,Region,City,Zip,Full_Name"
 
-	a := NewAlign(strings.NewReader(input), os.Stdout, comma, TextQualifier{On: false})
+	a := NewAlign(strings.NewReader(input), &bytes.Buffer{}, comma, TextQualifier{On: false})
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		a.splitWithQual(input, comma, "\"")
+	}
+}
+
+func BenchmarkExport(b *testing.B) {
+	input := "First,Middle,Last,Email,Region,City,Zip,Full_Name"
+
+	a := NewAlign(strings.NewReader(input), &bytes.Buffer{}, comma, TextQualifier{On: false})
+	lines := a.columnLength()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		a.export(lines)
 	}
 }

--- a/build.sh
+++ b/build.sh
@@ -22,22 +22,22 @@ case "$1" in
     "freebsd") 
         echo "Building binary for FreeBSD..."
         cd ${CMD_DIR}
-        GOOS=freebsd GOARCH=amd64 ${BUILD_CMD} bin/align-freebsd
+        GOOS=freebsd GOARCH=amd64 ${BUILD_CMD} ../../bin/align-freebsd
         ;;
     "darwin") 
         echo "Building binary for Darwin..."
         cd ${CMD_DIR}
-        GOOS=darwin GOARCH=amd64 ${BUILD_CMD} bin/align-darwin
+        GOOS=darwin GOARCH=amd64 ${BUILD_CMD} ../../bin/align-darwin
         ;;
     "linux") 
         echo "Building binary for Linux..."
         cd ${CMD_DIR}
-        GOOS=linux GOARCH=amd64 ${BUILD_CMD} bin/align-linux
+        GOOS=linux GOARCH=amd64 ${BUILD_CMD} ../../bin/align-linux
         ;;
     "windows") 
         echo "Building binary for Windows..."
         cd ${CMD_DIR}
-        GOOS=windows GOARCH=amd64 ${BUILD_CMD} bin/align-windows.exe
+        GOOS=windows GOARCH=amd64 ${BUILD_CMD} ../../bin/align-windows.exe
         ;;
 esac
 


### PR DESCRIPTION
Resolves #67 

Refactors a fair amount of the `export()` function to reduce some allocations.  
Running the same benchmark mentioned in #67, the allocs were reduced from 17 to 8.
