### PR TITLE
Issue72 transposed columns

### DIFF
--- a/align.go
+++ b/align.go
@@ -148,23 +148,23 @@ func fieldLenEscaped(s, sep, qual string) int {
 }
 
 func genFieldLen(s, sep, qual string) int {
-	var i int
-	if qual == "" || !strings.HasPrefix(s, qual) {
-		i = strings.Index(s, sep)
-	} else {
-		i = strings.Index(s, qual+sep)
+	var endIdx int
+	if len(qual) > 0 && strings.HasPrefix(s, qual) {
+		endIdx += len(qual)
 
-		if i == -1 {
-			return len(s)
-		}
-		return len(s[:i+len(qual)])
+		endIdx += strings.Index(s[endIdx:], qual) + len(qual)
+
+		return len(s[:endIdx])
 	}
 
-	if i == -1 {
+	endIdx += strings.Index(s, sep)
+
+	if endIdx == -1 {
+		// last field
 		return len(s)
 	}
 
-	return len(s[:i])
+	return len(s[:endIdx])
 }
 
 // columnLength scans the input and determines the maximum length of each field based on

--- a/align.go
+++ b/align.go
@@ -148,7 +148,7 @@ func fieldLenEscaped(s, sep, qual string) int {
 }
 
 func genFieldLen(s, sep, qual string) int {
-	i := 0
+	var i int
 	if qual == "" || !strings.HasPrefix(s, qual) {
 		i = strings.Index(s, sep)
 	} else {

--- a/align_test.go
+++ b/align_test.go
@@ -628,3 +628,98 @@ bilbo ,        , baggins     , bilbo@nothing.com , 444
 		t.Fatalf("export() = \n%v; want\n%v", got, expected)
 	}
 }
+
+func Test_genFieldLen(t *testing.T) {
+	type args struct {
+		s    string
+		sep  string
+		qual string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "Basic length",
+			args: args{
+				s:    "John",
+				sep:  ",",
+				qual: "\"",
+			},
+			want: 4,
+		},
+		{
+			name: "Qualified Len",
+			args: args{
+				s:    "\"John\"",
+				sep:  ",",
+				qual: "\"",
+			},
+			want: 6,
+		},
+		{
+			name: "Qualified Len with sep",
+			args: args{
+				s:    "\"John, M.\"",
+				sep:  ",",
+				qual: "\"",
+			},
+			want: 10,
+		},
+		{
+			name: "Qualified Len with space and sep",
+			args: args{
+				s:    "\" ,\"",
+				sep:  ",",
+				qual: "\"",
+			},
+			want: 4,
+		},
+		{
+			name: "Qualified Len with sep at start",
+			args: args{
+				s:    "\", abc\"",
+				sep:  ",",
+				qual: "\"",
+			},
+			want: 7,
+		},
+		{
+			name: "Qualified Len with sep at start not last field",
+			args: args{
+				s:    "\", abc\", ,",
+				sep:  ",",
+				qual: "\"",
+			},
+			want: 7,
+		},
+		{
+			name: "No qualifier not last field",
+			args: args{
+				s:    "abc d, ,",
+				sep:  ",",
+				qual: "",
+			},
+			want: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := genFieldLen(tt.args.s, tt.args.sep, tt.args.qual); got != tt.want {
+				t.Errorf("genFieldLen() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkGenFieldLen(b *testing.B) {
+	s := "\" , abc\", ,"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		genFieldLen(s, ",", "\"")
+	}
+}


### PR DESCRIPTION
Refactors an unexported function that counts the length of each field accordingly.

This function also benchmarked at about `10.1 ns/op` from `33.2 ns/op` on my particular machine after refactor.

Resolves #72 